### PR TITLE
chore(page): Add @typescipt-eslint to plugins in page package

### DIFF
--- a/page/.eslintrc.js
+++ b/page/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-    plugins: ["prettier"],
+    plugins: ["prettier", "@typescript-eslint"],
     extends: [
         "eslint:recommended",
         "@remix-run/eslint-config",


### PR DESCRIPTION
There was an eslint error with aliased paths on vscode.
<img width="750" alt="Screenshot 2023-03-16 at 13 24 31" src="https://user-images.githubusercontent.com/57555560/225616989-6e5a5da2-f47f-457e-881c-ed4c3c43c571.png">

To fix the problem I've added `@typescript-eslint` to eslint plugins in `page package.